### PR TITLE
feat(web): add Rybbit analytics

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
+import Script from "next/script";
 
 import "@workspace/ui/globals.css";
 import "streamdown/styles.css";
@@ -44,6 +45,11 @@ export default function RootLayout({
           {children}
           <Toaster position="bottom-right" richColors />
         </ThemeProvider>
+        <Script
+          src="https://as.heygaia.io/api/script.js"
+          data-site-id="a9885789f7dd"
+          strategy="afterInteractive"
+        />
       </body>
     </html>
   );


### PR DESCRIPTION
## Summary

- Adds the self-hosted Rybbit tracking script (https://as.heygaia.io) to `apps/web/app/layout.tsx`
- Loaded via `next/script` with `strategy="afterInteractive"` — off the critical path
- Site ID `a9885789f7dd` (registered as `motion.heygaia.io` in the Rybbit dashboard)

## Test plan
- [ ] Deploy preview
- [ ] Verify `https://as.heygaia.io/api/script.js` request in DevTools network tab
- [ ] Verify pageview appears in Rybbit dashboard for motion.heygaia.io