### PR TITLE
feat(social): connect Instagram/TikTok via upload-post + Integrations page

### DIFF
--- a/apps/web/app/api/social/accounts/route.ts
+++ b/apps/web/app/api/social/accounts/route.ts
@@ -1,0 +1,25 @@
+import { withAuth } from "@workos-inc/authkit-nextjs";
+import { NextResponse } from "next/server";
+import { getProfile, profileFor } from "@/lib/upload-post";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+/** Which social platforms the current user has connected via upload-post. */
+export async function GET() {
+  const { user } = await withAuth();
+  if (!user) {
+    return NextResponse.json({ error: "Unauthenticated" }, { status: 401 });
+  }
+
+  try {
+    const profile = await getProfile(profileFor(user.id));
+    const connected = Object.fromEntries(
+      Object.entries(profile.social_accounts ?? {}).map(([k, v]) => [k, !!v]),
+    );
+    return NextResponse.json({ connected });
+  } catch {
+    // No profile yet (or provider hiccup) → nothing connected.
+    return NextResponse.json({ connected: {} });
+  }
+}

--- a/apps/web/app/api/social/connect/route.ts
+++ b/apps/web/app/api/social/connect/route.ts
@@ -1,0 +1,40 @@
+import { withAuth } from "@workos-inc/authkit-nextjs";
+import { NextResponse } from "next/server";
+import {
+  ensureProfile,
+  generateConnectUrl,
+  profileFor,
+} from "@/lib/upload-post";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+/**
+ * Returns a hosted upload-post URL where the signed-in user links their
+ * Instagram/TikTok accounts. The client redirects the user to it.
+ */
+export async function POST() {
+  const { user } = await withAuth();
+  if (!user) {
+    return NextResponse.json({ error: "Unauthenticated" }, { status: 401 });
+  }
+
+  const appUrl = process.env.NEXT_PUBLIC_APP_URL ?? "https://www.keyloom.app";
+  const username = profileFor(user.id);
+
+  try {
+    await ensureProfile(username);
+    const url = await generateConnectUrl({
+      username,
+      platforms: ["instagram", "tiktok"],
+      redirectUrl: `${appUrl}/posts?connected=1`,
+    });
+    return NextResponse.json({ url });
+  } catch (err) {
+    console.error("social connect failed:", err);
+    return NextResponse.json(
+      { error: "Could not start social connection" },
+      { status: 502 },
+    );
+  }
+}

--- a/apps/web/app/api/social/publish/route.ts
+++ b/apps/web/app/api/social/publish/route.ts
@@ -1,6 +1,7 @@
 import { withAuth } from "@workos-inc/authkit-nextjs";
 import { NextResponse } from "next/server";
 import {
+  ensureProfile,
   profileFor,
   type SocialPlatform,
   uploadVideo,
@@ -9,15 +10,77 @@ import {
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-type PublishBody = {
-  /** Publicly fetchable MP4 (e.g. an R2 URL). */
-  videoUrl?: string;
+const KNOWN_PLATFORMS: SocialPlatform[] = [
+  "instagram",
+  "tiktok",
+  "youtube",
+  "facebook",
+  "linkedin",
+  "x",
+  "threads",
+];
+
+function parsePlatforms(raw: unknown): SocialPlatform[] {
+  const list = Array.isArray(raw) ? raw : [];
+  return list.filter((p): p is SocialPlatform =>
+    KNOWN_PLATFORMS.includes(p as SocialPlatform),
+  );
+}
+
+type PublishInput = {
+  /** The MP4 itself (multipart) or a publicly fetchable URL (JSON). */
+  video: Blob | string;
+  filename?: string;
+  platforms: SocialPlatform[];
   title?: string;
-  platforms?: SocialPlatform[];
   /** ISO-8601 in the future to schedule; omit to post now. */
   scheduledDate?: string;
   timezone?: string;
 };
+
+async function readInput(req: Request): Promise<PublishInput | null> {
+  const contentType = req.headers.get("content-type") ?? "";
+
+  if (contentType.includes("multipart/form-data")) {
+    const form = await req.formData().catch(() => null);
+    if (!form) return null;
+    const video = form.get("video");
+    if (!(video instanceof Blob) || video.size === 0) return null;
+    let platformsRaw: unknown = [];
+    try {
+      platformsRaw = JSON.parse((form.get("platforms") as string) || "[]");
+    } catch {
+      // Malformed platforms field → treated as empty → 400 below.
+    }
+    const platforms = parsePlatforms(platformsRaw);
+    if (!platforms.length) return null;
+    return {
+      video,
+      filename: video instanceof File ? video.name : undefined,
+      platforms,
+      title: (form.get("title") as string) || undefined,
+      scheduledDate: (form.get("scheduledDate") as string) || undefined,
+      timezone: (form.get("timezone") as string) || undefined,
+    };
+  }
+
+  const body = (await req.json().catch(() => ({}))) as {
+    videoUrl?: string;
+    platforms?: unknown;
+    title?: string;
+    scheduledDate?: string;
+    timezone?: string;
+  };
+  const platforms = parsePlatforms(body.platforms);
+  if (!body.videoUrl || !platforms.length) return null;
+  return {
+    video: body.videoUrl,
+    platforms,
+    title: body.title,
+    scheduledDate: body.scheduledDate,
+    timezone: body.timezone,
+  };
+}
 
 /** Post (or schedule) a rendered meme to the user's connected social accounts. */
 export async function POST(req: Request) {
@@ -26,22 +89,25 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: "Unauthenticated" }, { status: 401 });
   }
 
-  const body = (await req.json().catch(() => ({}))) as PublishBody;
-  if (!body.videoUrl || !body.platforms?.length) {
+  const input = await readInput(req);
+  if (!input) {
     return NextResponse.json(
-      { error: "videoUrl and at least one platform are required" },
+      { error: "A video (file or URL) and at least one platform are required" },
       { status: 400 },
     );
   }
 
   try {
+    const profile = profileFor(user.id);
+    await ensureProfile(profile);
     const result = await uploadVideo({
-      user: profileFor(user.id),
-      platforms: body.platforms,
-      videoUrl: body.videoUrl,
-      title: body.title,
-      scheduledDate: body.scheduledDate,
-      timezone: body.timezone,
+      user: profile,
+      platforms: input.platforms,
+      video: input.video,
+      filename: input.filename,
+      title: input.title,
+      scheduledDate: input.scheduledDate,
+      timezone: input.timezone,
       async: true,
     });
     return NextResponse.json(result);

--- a/apps/web/app/api/social/publish/route.ts
+++ b/apps/web/app/api/social/publish/route.ts
@@ -1,0 +1,55 @@
+import { withAuth } from "@workos-inc/authkit-nextjs";
+import { NextResponse } from "next/server";
+import {
+  profileFor,
+  type SocialPlatform,
+  uploadVideo,
+} from "@/lib/upload-post";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+type PublishBody = {
+  /** Publicly fetchable MP4 (e.g. an R2 URL). */
+  videoUrl?: string;
+  title?: string;
+  platforms?: SocialPlatform[];
+  /** ISO-8601 in the future to schedule; omit to post now. */
+  scheduledDate?: string;
+  timezone?: string;
+};
+
+/** Post (or schedule) a rendered meme to the user's connected social accounts. */
+export async function POST(req: Request) {
+  const { user } = await withAuth();
+  if (!user) {
+    return NextResponse.json({ error: "Unauthenticated" }, { status: 401 });
+  }
+
+  const body = (await req.json().catch(() => ({}))) as PublishBody;
+  if (!body.videoUrl || !body.platforms?.length) {
+    return NextResponse.json(
+      { error: "videoUrl and at least one platform are required" },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const result = await uploadVideo({
+      user: profileFor(user.id),
+      platforms: body.platforms,
+      videoUrl: body.videoUrl,
+      title: body.title,
+      scheduledDate: body.scheduledDate,
+      timezone: body.timezone,
+      async: true,
+    });
+    return NextResponse.json(result);
+  } catch (err) {
+    console.error("social publish failed:", err);
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : "Publish failed" },
+      { status: 502 },
+    );
+  }
+}

--- a/apps/web/app/integrations/page.tsx
+++ b/apps/web/app/integrations/page.tsx
@@ -1,0 +1,25 @@
+import { withAuth } from "@workos-inc/authkit-nextjs";
+import { redirect } from "next/navigation";
+import { IntegrationsClient } from "@/components/integrations/integrations-client";
+import { getProfile, profileFor } from "@/lib/upload-post";
+
+// Connection state is fetched live from upload-post per request.
+export const dynamic = "force-dynamic";
+
+export default async function IntegrationsPage() {
+  const { user } = await withAuth();
+  if (!user) redirect("/api/auth/signin");
+
+  // A platform is connected when upload-post has a non-empty handle for it.
+  let connected: Record<string, boolean> = {};
+  try {
+    const profile = await getProfile(profileFor(user.id));
+    connected = Object.fromEntries(
+      Object.entries(profile.social_accounts ?? {}).map(([k, v]) => [k, !!v]),
+    );
+  } catch {
+    // No profile yet (or key missing) → treat everything as not connected.
+  }
+
+  return <IntegrationsClient connected={connected} />;
+}

--- a/apps/web/components/app-sidebar.tsx
+++ b/apps/web/components/app-sidebar.tsx
@@ -11,6 +11,7 @@ import {
   Moon02Icon,
   PlugSocketIcon,
   Settings01Icon,
+  Share08Icon,
   Sun03Icon,
   UnfoldMoreIcon,
   UserCircleIcon,
@@ -87,7 +88,10 @@ const SECTIONS: NavSection[] = [
   },
   {
     label: "Integration",
-    items: [{ label: "MCP", href: "/mcp", icon: PlugSocketIcon }],
+    items: [
+      { label: "Integrations", href: "/integrations", icon: Share08Icon },
+      { label: "MCP", href: "/mcp", icon: PlugSocketIcon },
+    ],
   },
 ];
 

--- a/apps/web/components/integrations/integrations-client.tsx
+++ b/apps/web/components/integrations/integrations-client.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import {
+  InstagramIcon,
+  Tick02Icon,
+  TiktokIcon,
+} from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { Button } from "@workspace/ui/components/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@workspace/ui/components/card";
+import { useState } from "react";
+
+const PLATFORMS = [
+  { id: "instagram", label: "Instagram", icon: InstagramIcon },
+  { id: "tiktok", label: "TikTok", icon: TiktokIcon },
+] as const;
+
+export function IntegrationsClient({
+  connected,
+}: {
+  connected: Record<string, boolean>;
+}) {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const connect = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/social/connect", { method: "POST" });
+      const data = (await res.json()) as { url?: string; error?: string };
+      if (!res.ok || !data.url) {
+        throw new Error(data.error || "Could not start connection");
+      }
+      // upload-post's hosted page handles the actual OAuth for each platform.
+      window.location.href = data.url;
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Something went wrong");
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="mx-auto flex w-full max-w-3xl flex-col gap-6 px-6 py-10">
+      <header className="flex flex-col gap-1">
+        <h1 className="text-2xl font-semibold tracking-tight">Integrations</h1>
+        <p className="text-sm text-muted-foreground">
+          Connect your social accounts to publish and schedule memes straight to
+          Instagram and TikTok.
+        </p>
+      </header>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Social accounts</CardTitle>
+          <CardDescription>
+            You'll be sent to a secure page to authorize each account. We never
+            see your social passwords.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="flex flex-col gap-3">
+          <ul className="flex flex-col gap-2">
+            {PLATFORMS.map((p) => {
+              const isConnected = !!connected[p.id];
+              return (
+                <li
+                  key={p.id}
+                  className="flex items-center justify-between rounded-lg border border-border px-3 py-3"
+                >
+                  <div className="flex items-center gap-3">
+                    <div className="flex size-9 items-center justify-center rounded-md bg-muted">
+                      <HugeiconsIcon icon={p.icon} size={18} />
+                    </div>
+                    <span className="text-sm font-medium">{p.label}</span>
+                  </div>
+                  {isConnected ? (
+                    <span className="flex items-center gap-1.5 text-xs font-medium text-emerald-500">
+                      <HugeiconsIcon icon={Tick02Icon} size={14} />
+                      Connected
+                    </span>
+                  ) : (
+                    <span className="text-xs text-muted-foreground">
+                      Not connected
+                    </span>
+                  )}
+                </li>
+              );
+            })}
+          </ul>
+
+          {error ? <p className="text-xs text-destructive">{error}</p> : null}
+
+          <div>
+            <Button onClick={connect} disabled={loading}>
+              {loading ? "Opening…" : "Connect accounts"}
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/web/components/memes/meme-editor.tsx
+++ b/apps/web/components/memes/meme-editor.tsx
@@ -35,6 +35,7 @@ import {
   type Selected,
   type TextAttrs,
 } from "./meme-layout";
+import { MemePublishDialog } from "./meme-publish-dialog";
 
 // Force the canvas to be exactly 1080x1920 — no devicePixelRatio doubling. Set
 // at module load so it applies BEFORE Konva creates any canvas (a useEffect runs
@@ -257,9 +258,10 @@ export function MemeEditor({
     setMuted(v === 0);
   };
 
-  const handleExport = useCallback(async () => {
+  // Produce the final MP4 — the one pipeline behind both Download and Post.
+  const renderMp4 = useCallback(async (): Promise<Blob> => {
     const layer = layerRef.current;
-    if (!layer || !videoEl) return;
+    if (!layer || !videoEl) throw new Error("Editor is not ready yet");
     setSelected(null);
     const canvas = layer.getNativeCanvasElement();
     const prevLoop = videoEl.loop;
@@ -287,14 +289,9 @@ export function MemeEditor({
           onProgress: (f) => setStatus(`Encoding… ${Math.round(f * 100)}%`),
         });
         if (silent) {
-          let out = silent;
-          if (withAudio) {
-            setStatus("Adding audio…");
-            out = await muxAudioFromSource(silent, template.src, volume);
-          }
-          downloadBlob(out, `${template.id}-meme.mp4`);
-          setStatus("Downloaded ✓");
-          return;
+          if (!withAudio) return silent;
+          setStatus("Adding audio…");
+          return await muxAudioFromSource(silent, template.src, volume);
         }
         // silent === null → fast path unavailable here; fall back below.
       }
@@ -309,12 +306,7 @@ export function MemeEditor({
         onTick: () => {},
       });
       setStatus("Converting to MP4…");
-      const mp4 = await webmToMp4(webm);
-      downloadBlob(mp4, `${template.id}-meme.mp4`);
-      setStatus("Downloaded ✓");
-    } catch (err) {
-      console.error("Meme export failed:", err);
-      setStatus("Export failed — check the console");
+      return await webmToMp4(webm);
     } finally {
       videoEl.loop = prevLoop;
       videoEl.muted = prevMuted;
@@ -322,7 +314,30 @@ export function MemeEditor({
       if (!prevPaused) videoEl.play().catch(() => {});
       setExporting(false);
     }
-  }, [videoEl, template.src, template.id, volume]);
+  }, [videoEl, template.src, volume]);
+
+  const handleExport = useCallback(async () => {
+    try {
+      const mp4 = await renderMp4();
+      downloadBlob(mp4, `${template.id}-meme.mp4`);
+      setStatus("Downloaded ✓");
+    } catch (err) {
+      console.error("Meme export failed:", err);
+      setStatus("Export failed — check the console");
+    }
+  }, [renderMp4, template.id]);
+
+  // The publish dialog reports its own progress; clear the editor status line.
+  const renderForPublish = useCallback(async () => {
+    try {
+      const mp4 = await renderMp4();
+      setStatus(null);
+      return mp4;
+    } catch (err) {
+      setStatus(null);
+      throw err;
+    }
+  }, [renderMp4]);
 
   const patch = (p: Partial<Caption>) => setCaption((c) => ({ ...c, ...p }));
 
@@ -377,6 +392,12 @@ export function MemeEditor({
             <HugeiconsIcon icon={Download01Icon} size={16} />
             {exporting ? "Exporting…" : "Download MP4"}
           </Button>
+          <MemePublishDialog
+            renderVideo={renderForPublish}
+            defaultTitle={caption.text}
+            filename={`${template.id}-meme.mp4`}
+            disabled={exporting}
+          />
           {status && (
             <span className="text-sm text-muted-foreground">{status}</span>
           )}

--- a/apps/web/components/memes/meme-publish-dialog.tsx
+++ b/apps/web/components/memes/meme-publish-dialog.tsx
@@ -1,0 +1,242 @@
+"use client";
+
+import {
+  InstagramIcon,
+  Share08Icon,
+  Tick02Icon,
+  TiktokIcon,
+} from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { Button } from "@workspace/ui/components/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@workspace/ui/components/dialog";
+import { Input } from "@workspace/ui/components/input";
+import { Label } from "@workspace/ui/components/label";
+import { Switch } from "@workspace/ui/components/switch";
+import Link from "next/link";
+import { useEffect, useState } from "react";
+
+const PLATFORMS = [
+  { id: "instagram", label: "Instagram", icon: InstagramIcon },
+  { id: "tiktok", label: "TikTok", icon: TiktokIcon },
+] as const;
+
+type PlatformId = (typeof PLATFORMS)[number]["id"];
+
+type Stage =
+  | { kind: "idle" }
+  | { kind: "rendering" }
+  | { kind: "uploading" }
+  | { kind: "done"; scheduled: boolean }
+  | { kind: "error"; message: string };
+
+/**
+ * "Post" flow for a finished meme: render the MP4 in-browser, then hand the
+ * file to /api/social/publish, which forwards it to upload-post (no public
+ * hosting hop needed).
+ */
+export function MemePublishDialog({
+  renderVideo,
+  defaultTitle,
+  filename,
+  disabled,
+}: {
+  /** Produces the final MP4 (same pipeline as Download). */
+  renderVideo: () => Promise<Blob>;
+  defaultTitle: string;
+  filename: string;
+  disabled?: boolean;
+}) {
+  const [open, setOpen] = useState(false);
+  const [connected, setConnected] = useState<Record<string, boolean> | null>(
+    null,
+  );
+  const [selected, setSelected] = useState<Record<PlatformId, boolean>>({
+    instagram: false,
+    tiktok: false,
+  });
+  const [title, setTitle] = useState(defaultTitle);
+  const [scheduledAt, setScheduledAt] = useState("");
+  const [stage, setStage] = useState<Stage>({ kind: "idle" });
+
+  // Refresh connection state each time the dialog opens.
+  useEffect(() => {
+    if (!open) return;
+    setStage({ kind: "idle" });
+    setTitle(defaultTitle);
+    setConnected(null);
+    fetch("/api/social/accounts")
+      .then((r) => r.json())
+      .then((d: { connected?: Record<string, boolean> }) => {
+        const c = d.connected ?? {};
+        setConnected(c);
+        // Preselect everything that's already connected.
+        setSelected({ instagram: !!c.instagram, tiktok: !!c.tiktok });
+      })
+      .catch(() => setConnected({}));
+  }, [open, defaultTitle]);
+
+  const platforms = PLATFORMS.filter((p) => selected[p.id]).map((p) => p.id);
+  const busy = stage.kind === "rendering" || stage.kind === "uploading";
+  const noneConnected =
+    connected !== null && PLATFORMS.every((p) => !connected[p.id]);
+
+  const publish = async () => {
+    try {
+      setStage({ kind: "rendering" });
+      const mp4 = await renderVideo();
+
+      setStage({ kind: "uploading" });
+      const form = new FormData();
+      form.append("video", new File([mp4], filename, { type: "video/mp4" }));
+      form.append("platforms", JSON.stringify(platforms));
+      if (title.trim()) form.append("title", title.trim());
+      if (scheduledAt) {
+        form.append("scheduledDate", new Date(scheduledAt).toISOString());
+        form.append(
+          "timezone",
+          Intl.DateTimeFormat().resolvedOptions().timeZone,
+        );
+      }
+
+      const res = await fetch("/api/social/publish", {
+        method: "POST",
+        body: form,
+      });
+      const data = (await res.json().catch(() => ({}))) as { error?: string };
+      if (!res.ok) throw new Error(data.error || "Publish failed");
+      setStage({ kind: "done", scheduled: !!scheduledAt });
+    } catch (err) {
+      setStage({
+        kind: "error",
+        message: err instanceof Error ? err.message : "Something went wrong",
+      });
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => !busy && setOpen(o)}>
+      <DialogTrigger asChild>
+        <Button variant="secondary" disabled={disabled}>
+          <HugeiconsIcon icon={Share08Icon} size={16} />
+          Post
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Post to social</DialogTitle>
+          <DialogDescription>
+            Renders your meme and publishes it through your connected accounts.
+          </DialogDescription>
+        </DialogHeader>
+
+        {stage.kind === "done" ? (
+          <div className="flex flex-col items-center gap-2 py-6 text-center">
+            <span className="flex size-10 items-center justify-center rounded-full bg-emerald-500/15 text-emerald-500">
+              <HugeiconsIcon icon={Tick02Icon} size={20} />
+            </span>
+            <p className="text-sm font-medium">
+              {stage.scheduled ? "Scheduled ✓" : "Posted ✓"}
+            </p>
+            <p className="text-xs text-muted-foreground">
+              {stage.scheduled
+                ? "upload-post will publish it at the scheduled time."
+                : "It may take a minute to appear on your profiles."}
+            </p>
+          </div>
+        ) : (
+          <div className="flex flex-col gap-4">
+            <div className="flex flex-col gap-2">
+              {PLATFORMS.map((p) => {
+                const isConnected = !!connected?.[p.id];
+                return (
+                  <div
+                    key={p.id}
+                    className="flex items-center justify-between rounded-lg border border-border px-3 py-2.5"
+                  >
+                    <div className="flex items-center gap-2.5">
+                      <HugeiconsIcon icon={p.icon} size={18} />
+                      <span className="text-sm font-medium">{p.label}</span>
+                      {connected !== null && !isConnected && (
+                        <span className="text-xs text-muted-foreground">
+                          Not connected
+                        </span>
+                      )}
+                    </div>
+                    <Switch
+                      checked={selected[p.id]}
+                      disabled={!isConnected || busy}
+                      onCheckedChange={(v) =>
+                        setSelected((s) => ({ ...s, [p.id]: v }))
+                      }
+                    />
+                  </div>
+                );
+              })}
+              {noneConnected && (
+                <p className="text-xs text-muted-foreground">
+                  No accounts connected yet.{" "}
+                  <Link href="/integrations" className="underline">
+                    Connect Instagram or TikTok →
+                  </Link>
+                </p>
+              )}
+            </div>
+
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor="post-title">Caption</Label>
+              <Input
+                id="post-title"
+                value={title}
+                onChange={(e) => setTitle(e.target.value)}
+                placeholder="Say something…"
+                disabled={busy}
+              />
+            </div>
+
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor="post-schedule">Schedule (optional)</Label>
+              <Input
+                id="post-schedule"
+                type="datetime-local"
+                value={scheduledAt}
+                onChange={(e) => setScheduledAt(e.target.value)}
+                disabled={busy}
+              />
+              <p className="text-xs text-muted-foreground">
+                Leave empty to post right away.
+              </p>
+            </div>
+
+            {stage.kind === "error" && (
+              <p className="text-xs text-destructive">{stage.message}</p>
+            )}
+          </div>
+        )}
+
+        <DialogFooter>
+          {stage.kind === "done" ? (
+            <Button onClick={() => setOpen(false)}>Done</Button>
+          ) : (
+            <Button onClick={publish} disabled={busy || platforms.length === 0}>
+              {stage.kind === "rendering"
+                ? "Rendering…"
+                : stage.kind === "uploading"
+                  ? "Uploading…"
+                  : scheduledAt
+                    ? "Schedule"
+                    : "Post now"}
+            </Button>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/lib/upload-post.ts
+++ b/apps/web/lib/upload-post.ts
@@ -101,14 +101,17 @@ export async function getProfile(username: string): Promise<{
 }
 
 /**
- * Post (or schedule) a video to the given platforms for a profile. `videoUrl`
- * must be publicly fetchable (e.g. an R2 URL). Pass `scheduledDate` (ISO-8601,
- * in the future) + `timezone` to schedule instead of posting immediately.
+ * Post (or schedule) a video to the given platforms for a profile. `video` is
+ * either a publicly fetchable URL (e.g. an R2 URL) or the MP4 itself as a Blob
+ * — upload-post accepts both on the same endpoint. Pass `scheduledDate`
+ * (ISO-8601, in the future) + `timezone` to schedule instead of posting
+ * immediately.
  */
 export async function uploadVideo(opts: {
   user: string;
   platforms: SocialPlatform[];
-  videoUrl: string;
+  video: string | Blob;
+  filename?: string;
   title?: string;
   scheduledDate?: string;
   timezone?: string;
@@ -119,7 +122,11 @@ export async function uploadVideo(opts: {
   const form = new FormData();
   form.append("user", opts.user);
   for (const p of opts.platforms) form.append("platform[]", p);
-  form.append("video", opts.videoUrl);
+  if (typeof opts.video === "string") {
+    form.append("video", opts.video);
+  } else {
+    form.append("video", opts.video, opts.filename ?? "video.mp4");
+  }
   if (opts.title) form.append("title", opts.title);
   if (opts.scheduledDate) form.append("scheduled_date", opts.scheduledDate);
   if (opts.timezone) form.append("timezone", opts.timezone);

--- a/apps/web/lib/upload-post.ts
+++ b/apps/web/lib/upload-post.ts
@@ -1,0 +1,139 @@
+/**
+ * Thin server-side client for upload-post.com — our social posting provider.
+ *
+ * upload-post hosts the per-user OAuth connection (so we never touch Meta App
+ * Review / TikTok audit) and handles scheduling. We map each Keyloom user to an
+ * upload-post "profile" keyed by their user id.
+ *
+ * Auth: every request sends `Authorization: Apikey <UPLOAD_POST_API_KEY>`. The
+ * key is server-only — never expose it to the client.
+ */
+
+const BASE = "https://api.upload-post.com/api";
+
+export type SocialPlatform =
+  | "instagram"
+  | "tiktok"
+  | "youtube"
+  | "facebook"
+  | "linkedin"
+  | "x"
+  | "threads";
+
+function apiKey(): string {
+  const key = process.env.UPLOAD_POST_API_KEY;
+  if (!key) throw new Error("UPLOAD_POST_API_KEY is not set");
+  return key;
+}
+
+async function call<T>(
+  path: string,
+  init: RequestInit & { body?: BodyInit } = {},
+): Promise<T> {
+  const res = await fetch(`${BASE}${path}`, {
+    ...init,
+    headers: {
+      Authorization: `Apikey ${apiKey()}`,
+      ...init.headers,
+    },
+  });
+  const data = (await res.json().catch(() => ({}))) as T & {
+    success?: boolean;
+    message?: string;
+  };
+  if (!res.ok || data.success === false) {
+    throw new Error(
+      data.message || `upload-post ${path} failed (HTTP ${res.status})`,
+    );
+  }
+  return data as T;
+}
+
+/** Stable upload-post profile name for a Keyloom user. */
+export function profileFor(userId: string): string {
+  return `kl_${userId}`;
+}
+
+/** Create the profile if it doesn't exist yet (idempotent). */
+export async function ensureProfile(username: string): Promise<void> {
+  try {
+    await call("/uploadposts/users", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ username }),
+    });
+  } catch (err) {
+    // Already-exists is fine; rethrow anything else.
+    if (!/exist/i.test(err instanceof Error ? err.message : "")) throw err;
+  }
+}
+
+/**
+ * Generate the hosted URL where the user links their social accounts. Valid for
+ * 48h. `redirectUrl` is where upload-post sends them back after connecting.
+ */
+export async function generateConnectUrl(opts: {
+  username: string;
+  platforms?: SocialPlatform[];
+  redirectUrl?: string;
+}): Promise<string> {
+  const { access_url } = await call<{ access_url: string }>(
+    "/uploadposts/users/generate-jwt",
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        username: opts.username,
+        platforms: opts.platforms,
+        redirect_url: opts.redirectUrl,
+      }),
+    },
+  );
+  return access_url;
+}
+
+/** Which platforms a profile has connected (empty string = not connected). */
+export async function getProfile(username: string): Promise<{
+  username: string;
+  social_accounts: Record<string, string>;
+}> {
+  return call(`/uploadposts/users/${encodeURIComponent(username)}`);
+}
+
+/**
+ * Post (or schedule) a video to the given platforms for a profile. `videoUrl`
+ * must be publicly fetchable (e.g. an R2 URL). Pass `scheduledDate` (ISO-8601,
+ * in the future) + `timezone` to schedule instead of posting immediately.
+ */
+export async function uploadVideo(opts: {
+  user: string;
+  platforms: SocialPlatform[];
+  videoUrl: string;
+  title?: string;
+  scheduledDate?: string;
+  timezone?: string;
+  async?: boolean;
+}): Promise<
+  { request_id?: string; job_id?: string } & Record<string, unknown>
+> {
+  const form = new FormData();
+  form.append("user", opts.user);
+  for (const p of opts.platforms) form.append("platform[]", p);
+  form.append("video", opts.videoUrl);
+  if (opts.title) form.append("title", opts.title);
+  if (opts.scheduledDate) form.append("scheduled_date", opts.scheduledDate);
+  if (opts.timezone) form.append("timezone", opts.timezone);
+  if (opts.async) form.append("async_upload", "true");
+  return call("/upload", { method: "POST", body: form });
+}
+
+/** Poll an async (`request_id`) or scheduled (`job_id`) upload. */
+export async function getUploadStatus(params: {
+  requestId?: string;
+  jobId?: string;
+}): Promise<Record<string, unknown>> {
+  const q = new URLSearchParams();
+  if (params.requestId) q.set("request_id", params.requestId);
+  if (params.jobId) q.set("job_id", params.jobId);
+  return call(`/uploadposts/status?${q.toString()}`);
+}


### PR DESCRIPTION
## Summary
Adds social-account connection and a publish/schedule path using **upload-post** (which hosts the per-user OAuth and handles platform approval, so we don't touch Meta App Review / TikTok audit).

- **`lib/upload-post.ts`** — server client: ensure profile, generate hosted connect URL, upload/schedule video, poll status. Auth via `Authorization: Apikey`.
- **`POST /api/social/connect`** — returns the hosted URL where the signed-in user links their accounts.
- **`POST /api/social/publish`** — posts or schedules a video (public URL + platforms + optional `scheduledDate`) to the user's connected accounts.
- **Integrations page** (`/integrations`) + sidebar entry to connect Instagram/TikTok.

## Config
Requires `UPLOAD_POST_API_KEY` in the server environment (already in local `.env.local`; add to the deploy env).

## Follow-up (not in this PR)
Publishing needs the rendered meme MP4 at a public URL. Next step: upload the exported MP4 to R2 and pass that URL to `/api/social/publish`.